### PR TITLE
feat: add State design pattern with media player example

### DIFF
--- a/state-pattern/media_player.rb
+++ b/state-pattern/media_player.rb
@@ -1,0 +1,128 @@
+module State
+  def press_play(player)
+    raise NotImplementedError
+  end
+
+  def press_stop(player)
+    raise NotImplementedError
+  end
+
+  def press_pause(player)
+    raise NotImplementedError
+  end
+
+  def display
+    raise NotImplementedError
+  end
+end
+
+class StoppedState
+  include State
+
+  def press_play(player)
+    puts "Starting playback"
+    player.state = PlayingState.new
+  end
+
+  def press_stop(player)
+    puts "Already stopped"
+  end
+
+  def press_pause(player)
+    puts "Can't pause. Media is already stopped"
+  end
+
+  def display
+    puts "Current State: Stopped"
+  end
+end
+
+class PlayingState
+  include State
+
+  def press_play(player)
+    puts "Already playing"
+  end
+
+  def press_stop(player)
+    puts "Stopping playback"
+    player.state = StoppedState.new
+  end
+
+  def press_pause(player)
+    puts "Pausing playback"
+    player.state = PausedState.new
+  end
+
+  def display
+    puts "Current State: Playing"
+  end
+end
+
+class PausedState
+  include State
+
+  def press_play(player)
+    puts "Resuming playback"
+    player.state = PlayingState.new
+  end
+
+  def press_stop(player)
+    puts "Stopping playback from pause"
+    player.state = StoppedState.new
+  end
+
+  def press_pause(player)
+    puts "Already paused"
+  end
+
+  def display
+    puts "Current State: Paused"
+  end
+end
+
+class MediaPlayer
+  attr_accessor :state
+
+  def initialize(state)
+    unless state.is_a?(State)
+      raise ArgumentError, "state must implement State"
+    end
+
+    @state = state
+  end
+
+  def play
+    state.press_play(self)
+  end
+
+  def stop
+    state.press_stop(self)
+  end
+
+  def pause
+    state.press_pause(self)
+  end
+
+  def display_state
+    state.display
+  end
+end
+
+# Client Code
+
+player = MediaPlayer.new(StoppedState.new)
+
+player.display_state
+
+player.play
+player.display_state
+
+player.pause
+player.display_state
+
+player.play
+player.display_state
+
+player.stop
+player.display_state

--- a/state-pattern/media_player_application.py
+++ b/state-pattern/media_player_application.py
@@ -1,0 +1,115 @@
+from abc import ABC, abstractmethod
+
+
+class State(ABC):
+
+    @abstractmethod
+    def press_play(self, player):
+        pass
+
+    @abstractmethod
+    def press_stop(self, player):
+        pass
+
+    @abstractmethod
+    def press_pause(self, player):
+        pass
+
+    @abstractmethod
+    def display(self):
+        pass
+
+
+class StoppedState(State):
+
+    def press_play(self, player):
+        print("Starting playback")
+        player.state = PlayingState()
+
+    def press_stop(self, player):
+        print("Already stopped")
+
+    def press_pause(self, player):
+        print("Can't pause. Media is already stopped")
+
+    def display(self):
+        print("Current State: Stopped")
+
+
+class PlayingState(State):
+
+    def press_play(self, player):
+        print("Already playing")
+
+    def press_stop(self, player):
+        print("Stopping playback")
+        player.state = StoppedState()
+
+    def press_pause(self, player):
+        print("Pausing playback")
+        player.state = PausedState()
+
+    def display(self):
+        print("Current State: Playing")
+
+
+class PausedState(State):
+
+    def press_play(self, player):
+        print("Resuming playback")
+        player.state = PlayingState()
+
+    def press_stop(self, player):
+        print("Stopping playback from pause")
+        player.state = StoppedState()
+
+    def press_pause(self, player):
+        print("Already paused")
+
+    def display(self):
+        print("Current State: Paused")
+
+
+class MediaPlayer:
+
+    def __init__(self, state: State):
+        self.__state = state
+
+    @property
+    def state(self) -> State:
+        return self.__state
+
+    @state.setter
+    def state(self, state: State):
+        self.__state = state
+
+    def play(self):
+        self.__state.press_play(self)
+
+    def stop(self):
+        self.__state.press_stop(self)
+
+    def pause(self):
+        self.__state.press_pause(self)
+
+    def display(self):
+        self.__state.display()
+
+
+# Client Code
+
+player = MediaPlayer(StoppedState())
+
+player.display()
+
+player.play()
+player.display()
+
+player.pause()
+player.display()
+
+player.play()
+player.display()
+
+player.stop()
+player.display()

--- a/state-pattern/with_state_direction_service.py
+++ b/state-pattern/with_state_direction_service.py
@@ -1,0 +1,59 @@
+from enum import Enum
+from abc import ABC, abstractmethod
+
+# class TransportationMode(Enum):
+#     WALKING = 1
+#     CYCLING = 2
+#     CAR = 3
+#     TRAIN = 4
+
+class TransportationMode(ABC):
+    @abstractmethod
+    def get_direction(self) -> str:
+        pass
+
+    @abstractmethod
+    def calcETA(self) -> int:
+        pass
+
+class Walking(TransportationMode):
+    def calcETA(self) -> int:
+        print("Calculate ETA(Walking)...")
+        return 10
+    
+    def get_direction(self) -> str:
+        return "Direction for walking"
+
+class Cycling(TransportationMode):
+    def calcETA(self) -> int:
+        print("Calculate ETA(Cycling)...")
+        return 5
+    
+    def get_direction(self) -> str:
+        return "Direction for cycling"
+
+class DirectionService:
+    def __init__(self, mode: TransportationMode):
+        self.__mode = mode
+    
+    @property
+    def mode(self) -> TransportationMode:
+        return self.__mode
+    
+    @mode.setter
+    def mode(self, mode: TransportationMode) -> TransportationMode:
+        self.__mode = mode
+
+    def getETA(self) -> int:
+        return self.__mode.calcETA()
+    
+    def get_directon(self) -> str:
+        return self.__mode.get_direction()
+    
+
+walking = Walking()
+cycling = Cycling()
+direction_service = DirectionService(walking)
+print(direction_service.get_directon())
+print(direction_service.getETA())
+    

--- a/state-pattern/without_state_direction_service.py
+++ b/state-pattern/without_state_direction_service.py
@@ -1,0 +1,54 @@
+from enum import Enum
+
+class TransportationMode(Enum):
+    WALKING = 1
+    CYCLING = 2
+    CAR = 3
+    TRAIN = 4
+
+class DirectionService:
+    def __init__(self, mode: TransportationMode):
+        self.__mode = mode
+    
+    @property
+    def mode(self) -> TransportationMode:
+        return self.__mode
+
+    @mode.setter
+    def mode(self, mode: TransportationMode) -> TransportationMode:
+        self.__mode = mode
+
+    def getETA(self) -> int:
+        match self.__mode:
+            case TransportationMode.WALKING:
+                print("Calc ETA for walking")
+                return 10
+            case TransportationMode.CYCLING:
+                print("Calc ETA for Cycling")
+                return 5
+            case TransportationMode.CAR:
+                print("Calc ETA for CAR")
+                return 2
+            case TransportationMode.TRAIN:
+                print("Calc ETA for TRAIN")
+                return 3
+            case _:
+                print("Unknown Mode")
+
+    def get_direction(self) -> str:
+        match self.__mode:
+            case TransportationMode.WALKING:
+                return "Direction for walking: Head North for 500 metres"
+            case TransportationMode.CYCLING:
+                return "Direction for cycling: Take the bike lane on Elm Street"
+            case TransportationMode.CAR:
+                return "Direction for driving: Use highway 50 towards downtime."
+            case TransportationMode.TRAIN:
+                return "Direction for train: Board the Red Line at Central Station."
+            case _:
+                return "No direction available for the selected mode."
+
+direction_service = DirectionService(TransportationMode.TRAIN)
+direction_service.mode = TransportationMode.CYCLING
+print(direction_service.get_direction())
+print(direction_service.getETA())


### PR DESCRIPTION
## Summary
- Add State design pattern implementation under `state-pattern/`
- `media_player_application.py`: `State` interface + `Stopped`/`Playing`/`Paused` concrete states; `MediaPlayer` context delegates `play`/`stop`/`pause`/`display` to current state
- `media_player.rb`: Ruby version of same pattern
- `without_state_direction_service.py` / `with_state_direction_service.py`: before/after comparison showing State pattern benefit

## Test plan
- Run `python3 state-pattern/media_player_application.py` and verify state transitions print expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)