### PR TITLE
Add singleton design pattern examples

### DIFF
--- a/singleton_design_pattern/app_setting.py
+++ b/singleton_design_pattern/app_setting.py
@@ -1,0 +1,27 @@
+class SingletonModule(type):
+    _instances = {}
+    def __call__(klass, *args, **kwargs):
+        if klass not in klass._instances:
+            klass._instances[klass] = super().__call__(*args, **kwargs)
+        # print(type,args, kwargs, klass, klass._instances)
+        return klass._instances[klass]
+     
+class AppSetting(metaclass=SingletonModule):
+    # _instance = None
+
+    # def __new__(cls):
+    #     if cls._instance is None:
+    #         cls._instance = super().__new__(cls)
+    #     return cls._instance
+    
+    def __init__(self):
+        self.__databaseUrl: str = "jbdc://localhost:3306/mydatabase"
+        self.__apiKey: str = "12345-ABCDE"
+    
+    def get_database_url(self) -> str:
+        return self.__databaseUrl
+    
+    def get_api_key(self) -> str:
+        return self.__apiKey
+
+# app_settting = AppSetting()

--- a/singleton_design_pattern/databse.rb
+++ b/singleton_design_pattern/databse.rb
@@ -1,7 +1,12 @@
 module SingletonModule
     def self.included(base)
+        base.instance_variable_set(:@mutex, Mutex.new)
         def base.instance
-            @instance ||= new
+            return @instance if @instance
+            @mutex.synchronize do
+                @instance ||= new
+            end
+            @instance
         end
     end
 end

--- a/singleton_design_pattern/logger.py
+++ b/singleton_design_pattern/logger.py
@@ -1,0 +1,42 @@
+import threading
+class SingletonModule(type):
+    _instances = {}
+    _lock = threading.Lock()
+
+    def __call__(klass, *args, **kwargs):
+        with klass._lock:
+            if klass not in klass._instances:
+                klass._instances[klass] = super().__call__(*args, **kwargs)
+        return klass._instances[klass]
+
+class Logger(metaclass=SingletonModule):
+    def log(self, level: str, message: str):
+        print(level, message)
+
+    def info(self, message: str):
+        self.log("INFO", message)
+    
+    def warn(self, message: str):
+        self.log("WARN", message)
+    
+    def error(self, message: str):
+        self.log("ERROR", message)
+
+def worker():
+    logger = Logger()
+    print(id(logger))
+
+threads = []
+for _ in range(10):
+    t = threading.Thread(target= worker)
+    threads.append(t)
+    t.start()
+
+for t in threads:
+    t.join()
+
+info_logger = Logger()
+info_logger.info("Data got created!!!!")
+warn_logger = Logger()
+warn_logger.warn("Data has duplicacy present!!!")
+print(info_logger == warn_logger)

--- a/singleton_design_pattern/singleton.py
+++ b/singleton_design_pattern/singleton.py
@@ -1,0 +1,7 @@
+from app_setting import AppSetting
+
+app_setting_1 = AppSetting()
+app_setting_2 = AppSetting()
+print(app_setting_1.get_api_key())
+print(app_setting_2.get_api_key())
+print(app_setting_1 == app_setting_2)


### PR DESCRIPTION
## Summary
- Add Python singleton implementations using a metaclass
  - `app_setting.py` — `AppSetting` singleton holding DB URL + API key
  - `logger.py` — thread-safe `Logger` singleton (lock-guarded), verified across 10 threads
  - `singleton.py` — demo proving same instance returned
- Make Ruby `databse.rb` singleton thread-safe with a `Mutex` (double-checked locking)

## Test plan
- [ ] `python singleton.py` prints same API key + `True`
- [ ] `python logger.py` prints identical `id()` across threads + `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)