### PR TITLE
Add flyweight design pattern example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A collection of design pattern implementations and object-oriented design exerci
 | Adapter | `adapter-design-pattern/` | Python |
 | Composite | `composite-pattern/` | Python |
 | Decorator | `Decorator/`, `decorator-design-pattern/` | Ruby, Python |
+| Flyweight | `fly-weight-pattern/` | Python |
 | Proxy | `proxy-pattern/` | Python |
 
 ### Behavioral

--- a/fly-weight-pattern/bullet_management.py
+++ b/fly-weight-pattern/bullet_management.py
@@ -1,0 +1,32 @@
+class BulletType:
+    def __init__(self, color: str):
+        self.color = color
+
+class BulletTypeFactory:
+    bullet_type_store = {}
+    
+    @classmethod
+    def get_bullet_type(cls, color: str):
+        if color not in cls.bullet_type_store:
+            cls.bullet_type_store[color] = BulletType(color)
+        
+        return cls.bullet_type_store[color]
+        
+class Bullet:
+    def __init__(self, x:int, y:int, velocity: int, color: str):
+        self.x = x
+        self.y = y
+        self.velocity = velocity
+        self.color = BulletTypeFactory.get_bullet_type(color)
+    
+    def display(self):
+        print(f"Bullet at {self.x} {self.y} {self.velocity} {self.color.color}")
+
+
+for x in range(5):
+    bullet = Bullet(x*10, x*12, 5, "Red")
+    bullet.display()
+
+for y in range(10):
+    bullet = Bullet(y*10, y*12, 5, "Greeen")
+    bullet.display()

--- a/fly-weight-pattern/document_editor_application.py
+++ b/fly-weight-pattern/document_editor_application.py
@@ -1,0 +1,101 @@
+"""Document Editor using the Flyweight Design Pattern.
+
+Intrinsic (shared) state  -> font_size, color, font_style  (CharacterFlyWeight)
+Extrinsic (unique) state  -> the actual character glyph + its position in the document.
+
+The CharacterFactory caches one CharacterFlyWeight per unique formatting
+combination, so thousands of characters sharing the same formatting reuse a
+single object instead of allocating one each.
+"""
+
+
+class CharacterFlyWeight:
+    """Holds the shared (intrinsic) formatting attributes."""
+
+    def __init__(self, font_size, color, font_style):
+        self.font_size = font_size
+        self.color = color
+        self.font_style = font_style
+
+    def render(self, character):
+        """Render a glyph (extrinsic) using this shared formatting."""
+        return (
+            f"'{character}' "
+            f"[font_style={self.font_style}, "
+            f"font_size={self.font_size}, "
+            f"color={self.color}]"
+        )
+
+    def __repr__(self):
+        return (
+            f"CharacterFlyWeight(font_size={self.font_size!r}, "
+            f"color={self.color!r}, font_style={self.font_style!r})"
+        )
+
+
+class CharacterFactory:
+    """Creates and shares CharacterFlyWeight instances by formatting key."""
+
+    _characters_store = {}
+
+    @classmethod
+    def get_character(cls, font_size, color, font_style):
+        key = (font_size, color, font_style)
+        if key not in cls._characters_store:
+            cls._characters_store[key] = CharacterFlyWeight(font_size, color, font_style)
+        return cls._characters_store[key]
+
+    @classmethod
+    def total_flyweights(cls):
+        return len(cls._characters_store)
+
+
+class Document:
+    """A text document built from shared character flyweights."""
+
+    def __init__(self):
+        # each entry: (glyph, flyweight) -> flyweight carries shared formatting
+        self.characters = []
+
+    def add_character(self, character, font_size, color, font_style):
+        flyweight = CharacterFactory.get_character(font_size, color, font_style)
+        self.characters.append((character, flyweight))
+
+    def add_text(self, text, font_size, color, font_style):
+        for ch in text:
+            self.add_character(ch, font_size, color, font_style)
+
+    def render(self):
+        print("----- Document Render -----")
+        for character, flyweight in self.characters:
+            print(flyweight.render(character))
+        print("---------------------------")
+
+    def memory_report(self):
+        total = len(self.characters)
+        shared = CharacterFactory.total_flyweights()
+        print(f"Total characters in document : {total}")
+        print(f"Unique flyweight objects     : {shared}")
+        print(f"Objects saved by sharing     : {total - shared}")
+
+
+if __name__ == "__main__":
+    doc = Document()
+
+    # Same formatting -> all share ONE flyweight
+    doc.add_text("Hello", font_size="12", color="black", font_style="Arial")
+
+    # Different formatting -> new flyweight
+    doc.add_text(" World", font_size="14", color="red", font_style="Times")
+
+    # Reuse the first formatting again -> NO new flyweight created
+    doc.add_text("!!!", font_size="12", color="black", font_style="Arial")
+
+    doc.render()
+    print()
+    doc.memory_report()
+
+    # Confirm sharing: same key returns the SAME object
+    a = CharacterFactory.get_character("12", "black", "Arial")
+    b = CharacterFactory.get_character("12", "black", "Arial")
+    print(f"\nShared instance check (a is b): {a is b}")


### PR DESCRIPTION
## Summary
Adds a Flyweight design pattern example under `fly-weight-pattern/` and documents it in the README.

- `bullet_management.py` — bullets share `BulletType` flyweights via a factory keyed by color.
- `document_editor_application.py` — characters share `CharacterFlyWeight` formatting (intrinsic state) while glyph + position stay extrinsic; includes a memory report showing objects saved by sharing.
- README: new Flyweight row in the Structural patterns table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)